### PR TITLE
Fix #NI: Keep release-plz on attached branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
       - name: Verify the checked-out commit passed CI
         if: github.event_name == 'workflow_run'
         env:


### PR DESCRIPTION
## Summary

- check out the repository default branch by name so release-plz has an attached branch and upstream
- retain the existing equality guard that requires the checked-out SHA to match the commit that passed Build-Test
- leave version bumps and generated changelog entries owned by release-plz

## Validation

- Rust pre-push gate: clippy, nightly rustfmt, full tests, doctests, and live service integration tests
- actionlint 1.7.12
- Ruby YAML parsing
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
